### PR TITLE
디렉토리 삭제 도중 취소 시 목록이 삭제되지 않도록 하라

### DIFF
--- a/bin/fav.sh
+++ b/bin/fav.sh
@@ -62,8 +62,15 @@ Code repository: https://github.com/johngrib/fav-dir
 
     function _fav_remove_directory() {
         echo -n '' > $INDEX.temp
+
+        directories=$( __fav_get_list | fzf -m )
+
+        if [ -z "$directories" ]; then
+            return
+        fi
+
         echo $(
-            for directory in `__fav_get_list | fzf -m` ; do
+            for directory in $directories; do
                 grep -v "$directory" $INDEX >> $INDEX.temp
                 echo "Removed => $directory"
             done


### PR DESCRIPTION
디렉토리 삭제하는 도중에 `ctrl + c` 혹은 ESC키로 취소를 할 경우 저장되어 있는 모든 디렉토리 목록이 삭제됩니다.
취소를 하는 경우에는 아무런 일도 일어나지 않도록 수정합니다.

## 재현 방법

```
$ fav
```

![스크린샷 2023-09-07 오후 12 54 18](https://github.com/johngrib/fav-dir/assets/14071105/6b07310f-5c54-4024-a5dc-0a189aa56b1c)

```
$ fav rm
```

![스크린샷 2023-09-07 오후 12 54 36](https://github.com/johngrib/fav-dir/assets/14071105/38bddc1c-ae23-4395-adc8-9774e018d817)

여기서 ESC 혹은 `ctrl + c`

```
$ fav
```

![스크린샷 2023-09-07 오후 12 54 48](https://github.com/johngrib/fav-dir/assets/14071105/00943eb8-9863-4d82-8fe3-fcaf8d68cba9)

저장된 모든 목록이 삭제됨




