### PR TITLE
빈 스페이스가 포함된 디렉터리도 허용하라

### DIFF
--- a/bin/fav.sh
+++ b/bin/fav.sh
@@ -47,7 +47,7 @@ Code repository: https://github.com/johngrib/fav-dir
             *)
                 local TARGET_PATH=$(__fav_get_target_path)
                 if [ ! "$TARGET_PATH" = "" ]; then
-                    cd $TARGET_PATH
+                    cd "$TARGET_PATH"
                 fi
                 ;;
         esac


### PR DESCRIPTION
빈 스페이스가 포함된 디렉토리를 등록하고, 해당 디렉토리로 이동하려고 하면 "No such file of directory" 에러가 발생하고 있습니다.
`cd` 명령어를 사용할 때 그냥 `cd $TARGET_PATH`를 입력하게 되면 스페이스바로 구분된 디렉토리명은 별개의 인자로 인식합니다. 
예를들어서`/users/test test`라는 값이 `$TARGET_PATH`에 들어있었다면 명령어는 아래와 같이 해석됩니다.

```bash
$ cd /users/test test
-bash: cd: /users/test: No such file or directory
```

그래서 `cd` 명령어를 실행할 떄 `$TARGET_PATH`를 쌍 따옴표를 감싸서 하나의 명령어로 인식하도록 수정합니다.

```bash
$ cd "/users/test test"
```